### PR TITLE
Issue #38 - upgrade to swing-extras 2.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>ca.corbett</groupId>
             <artifactId>swing-extras</artifactId>
-            <version>2.5.0</version>
+            <version>2.6.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/src/main/resources/ca/corbett/extpackager/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/extpackager/ReleaseNotes.txt
@@ -1,6 +1,9 @@
 ExtPackager Release Notes
 Author: Steve Corbett
 
+Version 1.2 [2025-12-31]
+  #38 - Upgrade to swing-extras 2.6
+
 Version 1.1 [2025-12-01]
   #28 - add make-installer support
   #27 - fix multiple bugs in FTPUtil


### PR DESCRIPTION
This PR upgrades the swing-extras dependency from 2.5 to the latest 2.6-SNAPSHOT release. Confirmed that this project still builds and runs without issue. 

This will be changed again to `2.6` as soon as swing-extras 2.6 is out of SNAPSHOT.