### PR TITLE
Issue #35 - additional validation of extInfo on extension import

### DIFF
--- a/src/main/java/ca/corbett/packager/project/ProjectManager.java
+++ b/src/main/java/ca/corbett/packager/project/ProjectManager.java
@@ -244,30 +244,16 @@ public class ProjectManager {
                                         + " does not contain extInfo.json - this is not a valid extension jar.");
         }
 
-        // Make sure it targets the expected application:
-        // But only if we were given one to expect:
+        // Ensure validity:
         AppExtensionInfo extInfo = AppExtensionInfo.fromJson(extInfoStr);
-        if (expectedAppName != null) {
-            if (!expectedAppName.equals(extInfo.getTargetAppName())) {
-                throw new Exception("Unable to import Jar file "
-                                            + jarFile.getAbsolutePath()
-                                            + " because it targets the wrong application: "
-                                            + extInfo.getTargetAppName());
-            }
+        try {
+            validateExtInfo(extInfo, expectedAppName);
         }
-
-        // Additional extInfo validation:
-        if (extInfo.getMajorVersion() == 0) {
-            throw new Exception("Unable to parse version from extInfo.json in jar file "
+        catch (Exception e) {
+            // Augment the validation error with the jar file name and path:
+            throw new Exception("Error validating extInfo.json from jar file "
                                         + jarFile.getAbsolutePath()
-                                        + " - major version is missing or invalid: "
-                                        + extInfo.getVersion());
-        }
-        if (extInfo.getTargetAppMajorVersion() == 0) {
-            throw new Exception("Unable to parse target application version from extInfo.json in jar file "
-                                        + jarFile.getAbsolutePath()
-                                        + " - target application major version is missing or invalid: "
-                                        + extInfo.getTargetAppVersion());
+                                        + ": " + e.getMessage(), e);
         }
 
         return extInfo;
@@ -356,6 +342,41 @@ public class ProjectManager {
 
         extension.addVersion(extVersion);
         return extVersion;
+    }
+
+    /**
+     * Ensures that all required fields are present with sane values in the given AppExtensionInfo.
+     * If expectedAppName is not null, the targetAppName of the extInfo will be checked against it.
+     * If any field is missing or invalid, an exception is thrown.
+     */
+    protected void validateExtInfo(AppExtensionInfo extInfo, String expectedAppName) throws Exception {
+        // Make sure it targets the expected application:
+        // But only if we were given one to expect:
+        if (expectedAppName != null) {
+            if (!expectedAppName.equals(extInfo.getTargetAppName())) {
+                throw new Exception("Targets the wrong application: expected "
+                                            + "\"" + expectedAppName + "\""
+                                            + " but found "
+                                            + "\"" + extInfo.getTargetAppName() + "\"");
+            }
+        }
+
+        if (extInfo.getMajorVersion() == 0) {
+            throw new Exception("Extension major version is malformed: \""
+                                        + extInfo.getVersion()
+                                        + "\"");
+        }
+        if (extInfo.getTargetAppMajorVersion() == 0) {
+            throw new Exception("Target application major version is malformed: \""
+                                        + extInfo.getTargetAppVersion()
+                                        + "\"");
+        }
+        if (extInfo.getName() == null || extInfo.getName().isBlank()) {
+            throw new Exception("Extension name is missing or blank in extInfo.json.");
+        }
+        if (extInfo.getTargetAppName() == null || extInfo.getTargetAppName().isBlank()) {
+            throw new Exception("Target application name is missing or blank in extInfo.json.");
+        }
     }
 
     /**

--- a/src/main/resources/ca/corbett/extpackager/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/extpackager/ReleaseNotes.txt
@@ -2,7 +2,7 @@ ExtPackager Release Notes
 Author: Steve Corbett
 
 Version 1.2 [2025-12-31]
-  #40 - Remove tight UI coupling in ProjectManger
+  #40 - Remove tight UI coupling in ProjectManager
   #38 - Upgrade to swing-extras 2.6
   #35 - Additional validation of extInfo on import
 

--- a/src/test/java/ca/corbett/packager/project/ProjectManagerTest.java
+++ b/src/test/java/ca/corbett/packager/project/ProjectManagerTest.java
@@ -82,6 +82,89 @@ class ProjectManagerTest {
         assertEquals("hello", ProjectManager.getBasename("path/to/hello.txt"));
     }
 
+    @Test
+    public void validateExtInfo_withValidFields_shouldPass() throws Exception {
+        AppExtensionInfo extInfo = new AppExtensionInfo.Builder("MyExtension")
+                .setTargetAppName("TestApp")
+                .setTargetAppVersion("1.0")
+                .setVersion("1.0.0")
+                .build();
+        projectManager.validateExtInfo(extInfo, "TestApp");
+    }
+
+    @Test
+    public void validateExtInfo_withWrongTargetAppName_shouldThrow() {
+        AppExtensionInfo extInfo = new AppExtensionInfo.Builder("MyExtension")
+                .setTargetAppName("OtherApp")
+                .setTargetAppVersion("1.0")
+                .setVersion("1.0.0")
+                .build();
+        Exception exception = null;
+        try {
+            projectManager.validateExtInfo(extInfo, "TestApp");
+        }
+        catch (Exception e) {
+            exception = e;
+        }
+        assertNotNull(exception);
+        assertEquals("Targets the wrong application: expected \"TestApp\" but found \"OtherApp\"",
+                     exception.getMessage());
+    }
+
+    @Test
+    public void validateExtInfo_withBlankName_shouldThrow() {
+        AppExtensionInfo extInfo = new AppExtensionInfo.Builder("")
+                .setTargetAppName("TestApp")
+                .setTargetAppVersion("1.0")
+                .setVersion("1.0.0")
+                .build();
+        Exception exception = null;
+        try {
+            projectManager.validateExtInfo(extInfo, "TestApp");
+        }
+        catch (Exception e) {
+            exception = e;
+        }
+        assertNotNull(exception);
+        assertEquals("Extension name is missing or blank in extInfo.json.", exception.getMessage());
+    }
+
+    @Test
+    public void validateExtInfo_withBlankVersion_shouldThrow() {
+        AppExtensionInfo extInfo = new AppExtensionInfo.Builder("MyExtension")
+                .setTargetAppName("TestApp")
+                .setTargetAppVersion("1.0")
+                .setVersion("")
+                .build();
+        Exception exception = null;
+        try {
+            projectManager.validateExtInfo(extInfo, "TestApp");
+        }
+        catch (Exception e) {
+            exception = e;
+        }
+        assertNotNull(exception);
+        assertEquals("Extension major version is malformed: \"\"", exception.getMessage());
+    }
+
+    @Test
+    public void validateExtInfo_withBlankTargetAppVersion_shouldThrow() {
+        AppExtensionInfo extInfo = new AppExtensionInfo.Builder("MyExtension")
+                .setTargetAppName("TestApp")
+                .setTargetAppVersion("")
+                .setVersion("1.0.0")
+                .build();
+        Exception exception = null;
+        try {
+            projectManager.validateExtInfo(extInfo, "TestApp");
+        }
+        catch (Exception e) {
+            exception = e;
+        }
+        assertNotNull(exception);
+        assertEquals("Target application major version is malformed: \"\"", exception.getMessage());
+    }
+
     private static void deleteDirectoryRecursively(File rootDir) throws IOException {
         Path path = rootDir.toPath();
         if (Files.exists(path)) {


### PR DESCRIPTION
This PR adds additional validation for required fields in extInfo when importing extensions.

Specifically:
- the target app major version cannot evaluate to 0 (this implicitly also validates target app version)
- the extension major version cannot evaluate to 0 (this implicitly also validates extension version)

These fields are mandatory when creating an extension, so it's very unlikely they will ever be blank or malformed. This PR increases confidence in well-formed extInfo by validating these version fields before allowing the import.