### PR TITLE
Issue #30 - fix wonky label on target dir clean

### DIFF
--- a/src/main/java/ca/corbett/packager/ui/UploadCard.java
+++ b/src/main/java/ca/corbett/packager/ui/UploadCard.java
@@ -160,6 +160,7 @@ public class UploadCard extends JPanel implements ProjectListener {
 
     private void setFileUploadControlsVisible(boolean visible) {
         targetDirField.setVisible(visible);
+        cleanDirBeforeUpload.setCheckBoxText("Clean target directory before copying");
     }
 
     private void setFtpUploadControlsVisible(boolean visible) {
@@ -168,6 +169,7 @@ public class UploadCard extends JPanel implements ProjectListener {
         ftpPasswordField.setVisible(visible);
         ftpTargetDirField.setVisible(visible);
         ftpSaveParamsCheckbox.setVisible(visible);
+        cleanDirBeforeUpload.setCheckBoxText("Clean FTP directory before upload");
     }
 
     private void doUpload() {

--- a/src/main/resources/ca/corbett/extpackager/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/extpackager/ReleaseNotes.txt
@@ -7,6 +7,7 @@ Version 1.2 [2025-12-31]
   #35 - Additional validation of extInfo on import
   #34 - Add check for target dir existence on local deploy
   #33 - Add link to swing-extras-book from README
+  #30 - Fix wonky label on target dir clean checkbox
 
 Version 1.1 [2025-12-01]
   #28 - add make-installer support


### PR DESCRIPTION
This PR addresses an issue where the "target dir clean" checkbox label was not intelligently updated when switching between remote-upload deploys and local filesystem deploys. The label is now properly updated depending on the deploy type.