### PR TITLE
Issue #29 - fix wonky validation UI in update source dialog

### DIFF
--- a/src/main/java/ca/corbett/packager/ui/dialogs/UpdateSourceDialog.java
+++ b/src/main/java/ca/corbett/packager/ui/dialogs/UpdateSourceDialog.java
@@ -14,6 +14,9 @@ import javax.swing.BorderFactory;
 import javax.swing.JButton;
 import javax.swing.JDialog;
 import javax.swing.JPanel;
+import javax.swing.JScrollBar;
+import javax.swing.JScrollPane;
+import javax.swing.SwingUtilities;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
@@ -34,14 +37,17 @@ public class UpdateSourceDialog extends JDialog {
     private LabelField manifestField;
     private LabelField publicKeyField;
     private LabelField extensionsDirField;
+    private final JScrollPane scrollPane;
 
     public UpdateSourceDialog(String title) {
         super(MainWindow.getInstance(), title, true);
         setSize(new Dimension(600, 270));
-        setResizable(false);
+        setMinimumSize(new Dimension(500, 270));
+        setResizable(true);
         setLocationRelativeTo(MainWindow.getInstance());
         setLayout(new BorderLayout());
-        add(PropertiesDialog.buildScrollPane(buildFormPanel()), BorderLayout.CENTER);
+        scrollPane = PropertiesDialog.buildScrollPane(buildFormPanel());
+        add(scrollPane, BorderLayout.CENTER);
         add(buildButtonPanel(), BorderLayout.SOUTH);
     }
 
@@ -87,6 +93,12 @@ public class UpdateSourceDialog extends JDialog {
 
     private void buttonHandler(boolean okay) {
         if (okay && !formPanel.isFormValid()) {
+            // Scroll to the far right so that the validation icon is visible:
+            // (otherwise it's not obvious why the OK button seemed to do nothing!)
+            SwingUtilities.invokeLater(() -> {
+                JScrollBar horizontalBar = scrollPane.getHorizontalScrollBar();
+                horizontalBar.setValue(horizontalBar.getMaximum() - horizontalBar.getVisibleAmount());
+            });
             return;
         }
         wasOkayed = okay;

--- a/src/main/resources/ca/corbett/extpackager/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/extpackager/ReleaseNotes.txt
@@ -8,6 +8,7 @@ Version 1.2 [2025-12-31]
   #34 - Add check for target dir existence on local deploy
   #33 - Add link to swing-extras-book from README
   #30 - Fix wonky label on target dir clean checkbox
+  #29 - Fix UI validation wonkiness in update source dialog
 
 Version 1.1 [2025-12-01]
   #28 - add make-installer support


### PR DESCRIPTION
This PR addresses a minor UI issue in the UpdateSourceDialog, where the form field validation icons would appear at the far right side of the panel, potentially hidden by the scrollpane position. There were two adjustments here:

- make the dialog resizable with a certain minimum size, so the user can expand the dialog to see wide URLs
- force the scrollpane to the right if form validation fails, so that the validation error icon is immediately visible
