### PR TITLE
Issue #37 - decouple MainWindow from other classes

### DIFF
--- a/src/main/java/ca/corbett/packager/HyperlinkUtil.java
+++ b/src/main/java/ca/corbett/packager/HyperlinkUtil.java
@@ -1,0 +1,74 @@
+package ca.corbett.packager;
+
+import javax.swing.JOptionPane;
+import java.awt.Component;
+import java.awt.Desktop;
+import java.awt.Toolkit;
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.StringSelection;
+import java.net.URL;
+import java.util.logging.Logger;
+
+/**
+ * Utility class for hyperlink launching in JREs that support it.
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ * @since 1.2
+ */
+public class HyperlinkUtil {
+
+    private static final Logger log = Logger.getLogger(HyperlinkUtil.class.getName());
+    private static final Desktop desktop = Desktop.isDesktopSupported() ? Desktop.getDesktop() : null;
+
+    private HyperlinkUtil() {
+        // Utility class - prevent instantiation
+    }
+
+    /**
+     * Some JREs don't allow launching a hyperlink to open the browser.
+     */
+    public static boolean isBrowsingSupported() {
+        return desktop != null && desktop.isSupported(Desktop.Action.BROWSE);
+    }
+
+    /**
+     * If hyperlink launching is supported, will open the user's default browser to the
+     * given link (assuming the link is valid). If the JRE doesn't allow such things,
+     * then the given link will be copied to the clipboard instead (better than nothing).
+     * No message dialog will be shown on failure. If you wish to show a message dialog
+     * on failure, use the overload that accepts an owner Component.
+     */
+    public static void openHyperlink(String link) {
+        openHyperlink(link, null);
+    }
+
+    /**
+     * If hyperlink launching is supported, will open the user's default browser to the
+     * given link (assuming the link is valid). If the JRE doesn't allow such things,
+     * then the given link will be copied to the clipboard instead (better than nothing).
+     * If an owner Component is provided, a message dialog will be shown to inform
+     * the user that the link was copied to the clipboard.
+     */
+    public static void openHyperlink(String link, Component owner) {
+        if (isBrowsingSupported()) {
+            try {
+                desktop.browse(new URL(link).toURI());
+            }
+            catch (Exception e) {
+                log.warning("Unable to browse URI: " + e.getMessage());
+            }
+        }
+        else {
+            Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+            clipboard.setContents(new StringSelection(link), null);
+            if (owner != null) {
+                JOptionPane.showMessageDialog(owner, "Hyperlinks are not enabled in your JRE.\n"
+                                              + "Link copied to clipboard instead.",
+                        "Information", JOptionPane.INFORMATION_MESSAGE);
+            }
+            else {
+                log.info("Hyperlinks are not enabled in your JRE. Link copied to clipboard instead.");
+            }
+        }
+    }
+}

--- a/src/main/java/ca/corbett/packager/ui/IntroCard.java
+++ b/src/main/java/ca/corbett/packager/ui/IntroCard.java
@@ -8,6 +8,7 @@ import ca.corbett.forms.Margins;
 import ca.corbett.forms.fields.ComboField;
 import ca.corbett.forms.fields.LabelField;
 import ca.corbett.packager.AppConfig;
+import ca.corbett.packager.HyperlinkUtil;
 import ca.corbett.packager.Version;
 
 import javax.swing.AbstractAction;
@@ -35,10 +36,11 @@ public class IntroCard extends JPanel {
 
         formPanel.add(LabelField.createPlainHeaderLabel("Refer to the project page for full documentation:"));
         LabelField label = new LabelField(Version.PROJECT_URL);
+        final JPanel ownerCard = this;
         label.setHyperlink(new AbstractAction() {
             @Override
             public void actionPerformed(ActionEvent e) {
-                MainWindow.getInstance().openHyperlink(Version.PROJECT_URL);
+                HyperlinkUtil.openHyperlink(Version.PROJECT_URL, ownerCard);
             }
         });
         label.getMargins().setLeft(48);

--- a/src/main/java/ca/corbett/packager/ui/MainWindow.java
+++ b/src/main/java/ca/corbett/packager/ui/MainWindow.java
@@ -20,12 +20,8 @@ import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 import java.awt.BorderLayout;
 import java.awt.CardLayout;
-import java.awt.Desktop;
 import java.awt.Dimension;
 import java.awt.Font;
-import java.awt.Toolkit;
-import java.awt.datatransfer.Clipboard;
-import java.awt.datatransfer.StringSelection;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
@@ -59,13 +55,11 @@ public class MainWindow extends JFrame implements ProjectListener {
     private DefaultListModel<String> cardListModel;
     private JList<String> cardList;
     private JPanel contentPanel;
-    private final Desktop desktop;
     private File startupProjectFile = null;
     private LinkedHashMap<String, JPanel> cardMap = new LinkedHashMap<>();
 
     private MainWindow() {
         super(Version.APPLICATION_NAME + " " + Version.VERSION);
-        desktop = Desktop.isDesktopSupported() ? Desktop.getDesktop() : null;
         setSize(new Dimension(700, 520));
         setMinimumSize(new Dimension(500, 400));
         setLayout(new BorderLayout());
@@ -202,34 +196,6 @@ public class MainWindow extends JFrame implements ProjectListener {
         contentPanel = new JPanel();
         contentPanel.setLayout(new CardLayout());
         return contentPanel;
-    }
-
-    /**
-     * Some JREs don't allow launching a hyperlink to open the browser.
-     */
-    public boolean isBrowsingSupported() {
-        return desktop != null && desktop.isSupported(Desktop.Action.BROWSE);
-    }
-
-    /**
-     * If hyperlink launching is supported, will open the user's default browser to the
-     * given link (assuming the link is valid). If the JRE doesn't allow such things,
-     * then the given link will be copied to the clipboard instead (better than nothing).
-     */
-    public void openHyperlink(String link) {
-        if (isBrowsingSupported()) {
-            try {
-                desktop.browse(new URL(link).toURI());
-            }
-            catch (Exception e) {
-                log.warning("Unable to browse URI: " + e.getMessage());
-            }
-        }
-        else {
-            Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
-            clipboard.setContents(new StringSelection(link), null);
-            getMessageUtil().info("Hyperlinks are not enabled in your JRE.\nLink copied to clipboard instead.");
-        }
     }
 
     /**

--- a/src/main/java/ca/corbett/packager/ui/dialogs/ExtensionVersionDialog.java
+++ b/src/main/java/ca/corbett/packager/ui/dialogs/ExtensionVersionDialog.java
@@ -9,6 +9,7 @@ import ca.corbett.forms.Alignment;
 import ca.corbett.forms.FormPanel;
 import ca.corbett.forms.fields.ImageListField;
 import ca.corbett.forms.fields.LabelField;
+import ca.corbett.packager.HyperlinkUtil;
 import ca.corbett.packager.project.ProjectManager;
 import ca.corbett.packager.ui.MainWindow;
 import ca.corbett.updates.VersionManifest;
@@ -84,10 +85,11 @@ public class ExtensionVersionDialog extends JDialog {
         if (author != null && !author.isBlank()) {
             LabelField labelField = new LabelField("Author:", author);
             if (authorUrl != null && !authorUrl.isBlank()) {
+                final JDialog owner = this;
                 labelField.setHyperlink(new AbstractAction() {
                     @Override
                     public void actionPerformed(ActionEvent e) {
-                        MainWindow.getInstance().openHyperlink(authorUrl);
+                        HyperlinkUtil.openHyperlink(authorUrl, owner);
                     }
                 });
             }

--- a/src/main/resources/ca/corbett/extpackager/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/extpackager/ReleaseNotes.txt
@@ -4,6 +4,7 @@ Author: Steve Corbett
 Version 1.2 [2025-12-31]
   #40 - Remove tight UI coupling in ProjectManager
   #38 - Upgrade to swing-extras 2.6
+  #37 - Decouple MainWindow from other classes
   #35 - Additional validation of extInfo on import
   #34 - Add check for target dir existence on local deploy
   #33 - Add link to swing-extras-book from README


### PR DESCRIPTION
This PR decouples MainWindow from other classes by moving some functionality out of MainWindow and into a new generic utility class with optional UI support for error dialogs. Calling code no longer needs to be coupled to MainWindow just to access the URL browsing code.

The other MainWindow coupling problems mentioned in issue #37 were already addressed in the fix for issue #40. There are no other unnecessary references to MainWindow that I can find in the code (other than necessary uses of MainWindow as a parent for various dialogs).